### PR TITLE
Use new release tag format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Build and upload SQLite3 WASM
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-powersync.[0-9]+"
 
 jobs:
   compile_sqlite3_wasm:
@@ -25,7 +25,7 @@ jobs:
           overwrite: true
           file: sqlite3/.dart_tool/sqlite3_build/sqlite3.wasm
           asset_name: sqlite3.wasm
-          body: "SQLite3 WASM binary"
+          body: "PowerSync SQLite3 WASM binary"
           tag: ${{ github.ref_name }}
       - name: Upload sqlite3 debug binary
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
## Description

The release tags need to be updated to help distinguish between sqlite3 (e.g updates from upstream) and powersync-core changes. These changes are also for work done in PowerSync to ensure the correct binary is downloaded.

## Work done

- Update release tag format 